### PR TITLE
build 0.1.2 for AnacondaRecipes

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-upload_channels:
-  - sfe1ed40
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,6 +47,7 @@ test:
     - rouge_score
   imports:
     - rouge_score
+    - rouge_score.rouge_scorer
   requires:
     - pip
   commands:
@@ -117,5 +118,7 @@ about:
   dev_url: https://github.com/google-research/google-research/tree/master/rouge
 
 extra:
+  skip-lints:
+    - cbc_dep_in_run_missing_from_host
   recipe-maintainers:
     - sugatoray


### PR DESCRIPTION
rouge-score 0.1.2

**Destination channel:** defaults

### Links
- [PKG-15692](https://anaconda.atlassian.net/browse/PKG-15692)
- PyPI: https://pypi.org/project/rouge-score/0.1.2/

### Explanation of changes:
- AR-ify and first build of the stale conda-forge fork (already at 0.1.2 on `main`, never built for pkgs/main). Pure-Python, Apache-2.0. 

[PKG-15692]: https://anaconda.atlassian.net/browse/PKG-15692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ